### PR TITLE
ignored warnings for unexpected entries to stop filling up log files

### DIFF
--- a/pynetgear/__init__.py
+++ b/pynetgear/__init__.py
@@ -74,10 +74,10 @@ class Netgear(object):
                 # The last device, ignore the last element
                 info = data[start:-1]
 
-            if len(info) < 4:
-                if len(info) == 0:
-                    # don't warn on null lists just continue
-                    continue
+
+            if len(info) == 0:
+                continue
+            elif len(info) < 4:
                 _LOGGER.warning('Unexpected entry: %s', info)
                 continue
 

--- a/pynetgear/__init__.py
+++ b/pynetgear/__init__.py
@@ -75,6 +75,9 @@ class Netgear(object):
                 info = data[start:-1]
 
             if len(info) < 4:
+                if len(info) == 0:
+                    # don't warn on null lists just continue
+                    continue
                 _LOGGER.warning('Unexpected entry: %s', info)
                 continue
 


### PR DESCRIPTION
This fixes issue #4 from filling up log files in home-assistant with warnings of Unexpected entries.