### PR TITLE
Add get_traffic_meter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Logs in to the router. Will return True or False to indicate success.
 **get_attached_devices**<br>
 Returns a list of named tuples describing the device signal, ip, name, mac, type and link_rate.
 
+**get_traffic_meter**<br>
+Return a dict containing the traffic meter information from the router (if enabled in the webinterface).
+
 Installation
 ------------
 

--- a/capture/trafficmeter.request
+++ b/capture/trafficmeter.request
@@ -1,0 +1,11 @@
+POST /soap/server_sa/ HTTP/1.0
+SOAPAction: urn:NETGEAR-ROUTER:service:DeviceConfig:1#GetTrafficMeterStatistics
+content-type: text/xml;charset=utf-8
+HOST: www.routerlogin.com
+User-Agent: SOAP Toolkit 3.0
+connection: keep-Alive
+Cache-Control: no-cache
+Pragma: no-cache
+content-length: 543
+
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><SOAP-ENV:Envelope xmlns:SOAPSDK1="http://www.w3.org/2001/XMLSchema" xmlns:SOAPSDK2="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAPSDK3="http://schemas.xmlsoap.org/soap/encoding/" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"><SOAP-ENV:Header><SessionID>58DEE6006A88A967E89A</SessionID></SOAP-ENV:Header><SOAP-ENV:Body><M1:GetTrafficMeterStatistics xmlns:M1="urn:NETGEAR-ROUTER:service:DeviceConfig:1"></M1:GetTrafficMeterStatistics></SOAP-ENV:Body></SOAP-ENV:Envelope>

--- a/capture/trafficmeter.response
+++ b/capture/trafficmeter.response
@@ -1,0 +1,27 @@
+HTTP/1.0 200 OK
+CONTENT-LENGTH: 1361
+CONTENT-TYPE: text/xml; charset="utf-8"
+SERVER: Linux UPnP/1.0
+
+<?xml version="1.0" encoding="UTF-8"?><SOAP-ENV:Envelope xmlns:SOAPSDK1="http://www.w3.org/2001/XMLSchema" xmlns:SOAPSDK2="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAPSDK3="http://schemas.xmlsoap.org/soap/encoding/" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+  <SOAP-ENV:Body>
+    <m:GetTrafficMeterStatisticsResponse xmlns:m="urn:NETGEAR-ROUTER:service:DeviceConfig:1">
+      <NewTodayConnectionTime>00:14</NewTodayConnectionTime>
+      <NewTodayUpload>6.19</NewTodayUpload>
+      <NewTodayDownload>209.58</NewTodayDownload>
+      <NewYesterdayConnectionTime>00:00</NewYesterdayConnectionTime>
+      <NewYesterdayUpload>0.00</NewYesterdayUpload>
+      <NewYesterdayDownload>0.00</NewYesterdayDownload>
+      <NewWeekConnectionTime>00:14</NewWeekConnectionTime>
+      <NewWeekUpload>6.19/0.88</NewWeekUpload>
+      <NewWeekDownload>209.58/29.94</NewWeekDownload>
+      <NewMonthConnectionTime>00:14</NewMonthConnectionTime>
+      <NewMonthUpload>6.19/0.20</NewMonthUpload>
+      <NewMonthDownload>209.58/6.76</NewMonthDownload>
+      <NewLastMonthConnectionTime>00:00</NewLastMonthConnectionTime>
+      <NewLastMonthUpload>0.00/0.00</NewLastMonthUpload>
+      <NewLastMonthDownload>0.00/0.00</NewLastMonthDownload>
+    </m:GetTrafficMeterStatisticsResponse>
+    <ResponseCode>000</ResponseCode>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>


### PR DESCRIPTION
I downloaded the netgear genie app and ran it in wine to 
reverse-engineer GetTrafficMeterStatistics. This gives 
statistics about the internet traffic (when enabled in 
the interface).

I only tested this in python3, for now.