### PR TITLE
Fix unknown device parsing

### DIFF
--- a/pynetgear/__init__.py
+++ b/pynetgear/__init__.py
@@ -64,8 +64,11 @@ class Netgear(object):
         if not success:
             return None
 
-        data = re.search(r"<NewAttachDevice>(.*)</NewAttachDevice>",
-                         response).group(1).split(";")
+        raw_data = re.search(REGEX_ATTACHED_DEVICES, response).group(1)
+
+        # Netgear inserts a double-encoded value for "unknown" devices
+        data = data.replace(UNKNOWN_DEVICE_ENCODED,
+                            UNKNOWN_DEVICE_DECODED).split(";")
 
         devices = []
 
@@ -197,6 +200,8 @@ ACTION_GET_ATTACHED_DEVICES = \
 ACTION_GET_TRAFFIC_METER = \
     "urn:NETGEAR-ROUTER:service:DeviceConfig:1#GetTrafficMeterStatistics"
 
+REGEX_ATTACHED_DEVICES = r"<NewAttachDevice>(.*)</NewAttachDevice>"
+
 # Until we know how to generate it, give the one we captured
 SESSION_ID = "A7D88AE69687E58D9A00"
 
@@ -243,3 +248,6 @@ SOAP_TRAFFIC_METER = """
 </SOAP-ENV:Body>
 </SOAP-ENV:Envelope>
 """
+
+UNKNOWN_DEVICE_DECODED = '<unknown>'
+UNKNOWN_DEVICE_ENCODED = '&lt;unknown&gt;'

--- a/pynetgear/__init__.py
+++ b/pynetgear/__init__.py
@@ -69,7 +69,7 @@ class Netgear(object):
         # Netgear inserts a double-encoded value for "unknown" devices
         decoded = raw.replace(UNKNOWN_DEVICE_ENCODED, UNKNOWN_DEVICE_DECODED)
 
-        entries = data.split("@")
+        entries = decoded.split("@")
         devices = []
 
         # First element is the total device count
@@ -89,20 +89,21 @@ class Netgear(object):
 
             if len(info) == 0:
                 continue
-            elif len(info) != (4 or 6):
+            
+            # Not all routers will report link type and rate
+            if len(info) == 7:
+                link_type = info[4]
+                link_rate = convert(info[5], int)
+                signal = convert(info[6], int)                    
+            elif len(info) == 4:
+                signal = 100
+                link_type = None
+                link_rate = 0
+            else:
                 _LOGGER.warning("Unexpected entry: %s", info)
                 continue
 
-            signal = int(info[0])
             ipv4, name, mac = info[1:4]
-
-            # Not all routers will report link type and rate
-            if len(info) == 6:
-                link_type = info[4]
-                link_rate = convert(info[5], int)
-            else:
-                link_type = None
-                link_rate = 0
 
             devices.append(Device(signal, ipv4, name, mac, link_type,
                                   link_rate))
@@ -197,6 +198,7 @@ def convert(value, to_type, default=None):
     except ValueError:
         # If value could not be converted
         return default
+
 
 ACTION_LOGIN = "urn:NETGEAR-ROUTER:service:ParentalControl:1#Authenticate"
 ACTION_GET_ATTACHED_DEVICES = \

--- a/pynetgear/__init__.py
+++ b/pynetgear/__init__.py
@@ -77,7 +77,7 @@ class Netgear(object):
 
         for index, start in enumerate(device_start):
             try:
-                info = data[start:device_start[index+1]]
+                info = data[start:device_start[index + 1]]
             except IndexError:
                 # The last device, ignore the last element
                 info = data[start:-1]
@@ -118,10 +118,10 @@ class Netgear(object):
                 This function parses the different values and returns
                 (total, avg), timedelta or a plain float
             """
-            tofloats = lambda lst: (float(t) for t in lst)
-            if "/" in text: # "6.19/0.88" total/avg
+            def tofloats(lst): return (float(t) for t in lst)
+            if "/" in text:  # "6.19/0.88" total/avg
                 return tuple(tofloats(text.split('/')))
-            elif ":" in text: # 11:14 hr:mn
+            elif ":" in text:  # 11:14 hr:mn
                 hour, mins = tofloats(text.split(':'))
                 return timedelta(hours=hour, minutes=mins)
             else:
@@ -244,7 +244,8 @@ SOAP_TRAFFIC_METER = """
 <SessionID>{session_id}</SessionID>
 </SOAP-ENV:Header>
 <SOAP-ENV:Body>
-<M1:GetTrafficMeterStatistics xmlns:M1="urn:NETGEAR-ROUTER:service:DeviceConfig:1"></M1:GetTrafficMeterStatistics>
+<M1:GetTrafficMeterStatistics \
+ xmlns:M1="urn:NETGEAR-ROUTER:service:DeviceConfig:1"></M1:GetTrafficMeterStatistics>
 </SOAP-ENV:Body>
 </SOAP-ENV:Envelope>
 """

--- a/test/test_getAttachedDevices.py
+++ b/test/test_getAttachedDevices.py
@@ -1,0 +1,88 @@
+import unittest
+from unittest import mock
+from pynetgear import Netgear, Device
+
+
+class TestGetAttachedDevices(unittest.TestCase):
+
+    def test_noSignalType(self):
+        spy = NetgearSpy(RESPONSE_NO_SIGNAL_TYPE)
+        mocked_netgear = mock.Mock(wraps=spy)
+
+        result = spy.get_attached_devices()
+        assert result == [Device(signal=100, ip='192.168.1.4',
+                                 name='MACBOOK-PRO', mac='80:E6:50:13:2B:E0',
+                                 type=None, link_rate=0),
+                          Device(signal=100, ip='192.168.1.18',
+                                 name='RASPBERRYPI', mac='B8:27:EB:D9:05:E1',
+                                 type=None, link_rate=0)]
+
+    def test_withSignalType(self):
+        spy = NetgearSpy(RESPONSE_WITH_SIGNAL_TYPE)
+        mocked_netgear = mock.Mock(wraps=spy)
+
+        result = spy.get_attached_devices()
+        assert result == [Device(signal=88, ip='192.168.1.2',
+                                 name='android-ada682e3ff4d6b20',
+                                 mac='10:68:3F:AA:AA:AA',
+                                 type='wireless', link_rate=72),
+                          Device(signal=100, ip='192.168.1.3', name='odin',
+                                 mac='C8:9C:DC:AA:AA:AA', type='wired',
+                                 link_rate=None)]
+
+    def test_invalidResponse(self):
+        spy = NetgearSpy(RESPONSE_INVALID)
+        mocked_netgear = mock.Mock(wraps=spy)
+        result = spy.get_attached_devices()
+        assert result is None
+
+    def test_responseMissingSplitChar(self):
+        spy = NetgearSpy(RESPONSE_MISSGING_SPLIT_CHAR)
+        mocked_netgear = mock.Mock(wraps=spy)
+        result = spy.get_attached_devices()
+        assert result is None
+
+    def test_responseUnknownDevice(self):
+        spy = NetgearSpy(RESONSE_UNKOWN_DEVICE)
+        mocked_netgear = mock.Mock(wraps=spy)
+        result = spy.get_attached_devices()
+        assert result == [Device(signal=100, ip='192.168.1.2',
+                                 name='<unknown>',
+                                 mac='10:68:3F:AA:AA:AA',
+                                 type=None, link_rate=0)]
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+
+class NetgearSpy(Netgear):
+    def __init__(self, response):
+        super().__init__
+        self.response = response
+
+    def _make_request(self, action, message, try_login_after_failure=True):
+        result = True
+        response = self.response
+        return result, response
+
+
+RESPONSE_NO_SIGNAL_TYPE = "<NewAttachDevice>\
+2@1;192.168.1.4;MACBOOK-PRO;80:E6:50:13:2B:E0\
+@3;192.168.1.18;RASPBERRYPI;B8:27:EB:D9:05:E1\
+</NewAttachDevice>"
+
+RESPONSE_WITH_SIGNAL_TYPE = "<NewAttachDevice>\
+2@1;192.168.1.2;android-ada682e3ff4d6b20;10:68:3F:AA:AA:AA;wireless;72;88\
+@2;192.168.1.3;odin;C8:9C:DC:AA:AA:AA;wired;;100\
+</NewAttachDevice>"
+
+RESPONSE_INVALID = "INVALID"
+
+RESPONSE_MISSGING_SPLIT_CHAR = "<NewAttachDevice>\
+UNKNOWN#FORMATTING\
+</NewAttachDevice>"
+
+RESONSE_UNKOWN_DEVICE = "<NewAttachDevice>\
+1@1;192.168.1.2;&lt;unknown&gt;;10:68:3F:AA:AA:AA\
+</NewAttachDevice>"


### PR DESCRIPTION
This fixes #10 

Currently tested only on a Netgear WNDR3700v2 with Firmware V1.0.1.14

@balloob I changed the way of parsing (now splitting at "@" char), as it seems to be the determining char for a attached device in the response. For my router the scheme looks like:
`<NewAttachDevice>TOTAL_DEVICES_ATTACHED@DEVICE_#;DEVICE#_IP;DEVICE#_HOSTNAME;DEVICE#_MAC@DEVICE_#;DEVICE#_IP;DEVICE#_HOSTNAME;DEVICE#_MAC</NewAttachDevice>`

However, for a router reporting link type and rate a response might look like this:
 `@4;192.168.1.5;android-e948fcdcfcf326b;AC:22:0B:AA:AA:AA;wireless;150;72`
which rather corresponds to 
`@DEVICE_#;DEVICE#_IP;DEVICE#_HOSTNAME;DEVICE#_MAC;DEVICE#_LINK-TYPE,DEVICE#_SIGNAL(?),DEVICE#_?`

Do you have an Idea what the last two values stand for?
Does DEVICE_# correspond to singnal-strength?

For code-style and linting i tried to follow the HASS guidelines, which is hopefully ok for you.
